### PR TITLE
Wrong (this) Scope in setInterval

### DIFF
--- a/src/routes/hello/components/stop-watch/index.marko
+++ b/src/routes/hello/components/stop-watch/index.marko
@@ -17,7 +17,7 @@ class {
   handleStartClick() {
     this.state.running = true;
 
-    this.intervalId = setInterval(function () {
+    this.intervalId = setInterval(() => {
       this.state.elapsedTime += 0.1;
     }, 100);
   }


### PR DESCRIPTION
The `this` scope in setInterval is bound to the native setInterval and not the class.
I was getting this error: `Uncaught TypeError: Cannot read property 'elapsedTime' of undefined`